### PR TITLE
Assembly updates to the djland api

### DIFF
--- a/api/api_common.php
+++ b/api/api_common.php
@@ -31,7 +31,7 @@ function finish(){
             }
   } else {
 
-    if ( is_array($data) && sizeof($data) == 1 ) $data = $data[0];
+    //if ( is_array($data) && sizeof($data) == 1 ) $data = $data[0];
 
     foreach($data as $i => $v){
 

--- a/api/playlist/index.php
+++ b/api/playlist/index.php
@@ -9,26 +9,22 @@
 
 require_once('../api_common.php');
 
-if (isset($_GET['ID'])){
-  $id = $_GET['ID'];
-} else {
-  $error .= ' please supply playlist id ( /playlist?ID=## ) ';
-  $blame_request = true;
+
+$id = isset($_GET['ID']) && is_numeric($_GET['ID']) ? $_GET['ID'] * 1 : 0;
+
+if (!$id) {
+	$error = "[ERROR] please supply a numeric playlist id ( /playlist?ID=##) ";
+	$blame_request = true;
+	finish();
+	exit;
 }
 
-if (!is_numeric($id)){
-  $error .= ' ID parameter should not be a string ';
-  $blame_request = true;
-}
-
-if ($error != '') finish();
-
-$query = 'SELECT
+$query = "SELECT
           playlists.id as playlist_id,
           playlists.show_id,
           playlists.start_time,
           playlists.end_time,
-          playlists.edit_date,
+          GREATEST(playlists.edit_date, COALESCE(podcast_episodes.edit_date,'0000-00-00 00:00:00')) as edit_date,
           playlists.type as playlist_type,
           playlists.spokenword as transcript,
           hosts.name as host_name,
@@ -36,21 +32,30 @@ $query = 'SELECT
           podcast_episodes.summary as episode_description,
           podcast_episodes.title as episode_title,
           podcast_episodes.url as episode_audio
+
           FROM playlists
+          join shows on shows.id = playlists.show_id
           LEFT JOIN hosts on hosts.id = playlists.host_id
           LEFT JOIN podcast_episodes on podcast_episodes.id = playlists.podcast_episode
-          WHERE playlists.status = 2 AND playlists.id ='.$id;
+
+          WHERE playlists.status = 2 AND playlists.id=$id";
 
 $rawdata = array();
 
 if ( $result = mysqli_query($db, $query) ) {
   if (mysqli_num_rows($result) == 0) {
-    $error .= "no finished playlist found with this ID: ".$id;
-    $blame_request = true;
+    //$error = " no playlist found with this ID: ".$id;
+    //$blame_request = true;
+    $data = array(
+    	'api_message' => '[NO RECORD FOUND]',
+    	'message'     => 'no playlist found with this ID: '.$id,
+    );
+    finish();
+	exit;
   }
   while ($row = mysqli_fetch_assoc($result)) {
     $rawdata = $row;
-
+    break;
   }
 
   $plays = array();
@@ -59,8 +64,8 @@ if ( $result = mysqli_query($db, $query) ) {
 
   if ($result2 = mysqli_query($db, $query)){
       if (mysqli_num_rows($result2) == 0){
-        $error .= " no plays in this playlist! ";
-        $blame_request = true;
+        //$error .= " no plays in this playlist! ";
+        //$blame_request = true;
       } else {
 
         while ($row = mysqli_fetch_assoc($result2)){
@@ -92,6 +97,5 @@ if(isset($rawdata['episode_audio']) && $rawdata['episode_audio'] == ""){
 }
 
 $data = $rawdata;
-
 
 finish();

--- a/api/playlists/index.php
+++ b/api/playlists/index.php
@@ -10,21 +10,20 @@ $rawdata = array();
 global $_GET;
 global $db;
 
-if(isset($_GET['OFFSET'])) $offset = $_GET['OFFSET']; else $offset = 0;
-if(isset($_GET['LIMIT'])) $limit = $_GET['LIMIT']; else $limit = 100;
+$offset = isset($_GET['OFFSET']) && is_numeric($_GET['OFFSET']) ? $_GET['OFFSET'] * 1 : 0;
+$limit  = isset($_GET['LIMIT'])  && is_numeric($_GET['LIMIT'])  ? $_GET['LIMIT']  * 1 : 100;
 
+$query =   "SELECT playlists.id,
+			GREATEST(playlists.edit_date, COALESCE(podcast_episodes.edit_date,'0000-00-00 00:00:00')) as edit_date
 
+			FROM playlists
+			join shows on shows.id = playlists.show_id
+			LEFT JOIN podcast_episodes on playlists.podcast_episode = podcast_episodes.id
 
-  $query = '
-    SELECT playlists.id,
-      GREATEST(playlists.edit_date, podcast_episodes.edit_date) as edit_date
-    FROM playlists
-    LEFT JOIN podcast_episodes on playlists.podcast_episode = podcast_episodes.id
-
-    ORDER BY
-      GREATEST(playlists.edit_date, podcast_episodes.edit_date)
-    DESC limit ' . $limit . ' OFFSET ' . $offset;
-
+			WHERE playlists.status = 2
+			ORDER BY GREATEST(playlists.edit_date, COALESCE(podcast_episodes.edit_date,'0000-00-00 00:00:00')) DESC
+			LIMIT $limit
+			OFFSET $offset";
 
 if ($result = mysqli_query($db, $query) ) {
 
@@ -36,9 +35,6 @@ if ($result = mysqli_query($db, $query) ) {
 } else {
   $error .= mysqli_error($db);
 }
-
-
-
 
 $data = $rawdata;
 

--- a/api/show/index.php
+++ b/api/show/index.php
@@ -9,166 +9,81 @@
 
 require_once('../api_common.php');
 
+$id = isset($_GET['ID']) && is_numeric($_GET['ID']) ? $_GET['ID'] * 1 : 0;
 
-
-$rawdata = array();
-
-
-$query = 'SELECT '.
-    "shows.id as show_id,
-       shows.name,
-       shows.last_show,
-       shows.create_date,
-       shows.edit_date,
-       shows.active,
-       shows.primary_genre_tags,
-       shows.secondary_genre_tags,
-       shows.website,
-       shows.rss,
-       shows.show_desc,
-       shows.alerts,
-       shows.show_img,
-       hosts.name as host_name,
-        podcast_channels.title as podcast_title,
-        podcast_channels.subtitle as podcast_subtitle,
-        podcast_channels.summary as podcast_summary,
-        podcast_channels.keywords as podcast_keywords,
-        podcast_channels.image_url as podcast_image_url,
-        podcast_channels.xml as podcast_xml,
-        podcast_channels.edit_date as podcast_edit_date,
-       social.social_name,
-       social.social_url,
-       social.short_name,
-       social.unlink  ".
-    "FROM shows LEFT JOIN hosts on hosts.id = shows.host_id ".
-    "JOIN social on show_id = shows.id
-    LEFT JOIN podcast_channels on podcast_channels.id = shows.podcast_channel_id";
-
-
-
-if ( isset($_GET['ID'])){
-//  fetch id
-  $id = $_GET['ID'];
-
-  $query .=' WHERE shows.id = '.$id.'';
-
-} else {
-  $error .= " please supply show id ( show?ID=##) ";
-  $blame_request = true;
-
-  //error
+if (!$id) {
+	$error = "[ERROR] please supply a numeric show id ( show?ID=##) ";
+	$blame_request = true;
+	finish();
+	exit;
 }
 
-if (!is_numeric($id)){
-  $error .= ' ID parameter should not be a string ';
-  $blame_request = true;
-}
 
-if($error != '') finish();
+$query =   "SELECT
+			shows.id as show_id,
+			shows.name,
+			shows.last_show,
+			shows.create_date,
+			GREATEST(shows.edit_date,COALESCE(podcast_channels.edit_date,'0000-00-00 00:00:00')) as edit_date,
+			shows.active,
+			shows.primary_genre_tags,
+			shows.secondary_genre_tags,
+			shows.website,
+			shows.rss,
+			shows.show_desc,
+			shows.alerts,
+			shows.show_img,
+			hosts.name as host_name,
+			podcast_channels.title as podcast_title,
+			podcast_channels.subtitle as podcast_subtitle,
+			podcast_channels.summary as podcast_summary,
+			podcast_channels.keywords as podcast_keywords,
+			podcast_channels.image_url as podcast_image_url,
+			podcast_channels.xml as podcast_xml
+
+			FROM shows
+
+			LEFT JOIN hosts on hosts.id = shows.host_id
+			LEFT JOIN podcast_channels on podcast_channels.id = shows.podcast_channel_id
+
+			WHERE shows.id=$id";
+
+$data = array();
 
 if ($result = mysqli_query($db, $query) ) {
+	$data = mysqli_fetch_assoc($result);
 
-  if (mysqli_num_rows($result) == 0) {
-
-    // now try again without socials
-    $query = 'SELECT '.
-        "shows.id as show_id,
-       shows.name,
-       shows.last_show,
-       shows.create_date,
-       shows.edit_date,
-       shows.active,
-       shows.primary_genre_tags,
-       shows.secondary_genre_tags,
-       shows.website,
-       shows.rss,
-       shows.show_desc,
-       shows.alerts,
-       shows.show_img,
-       hosts.name as host_name,
-        podcast_channels.title as podcast_title,
-        podcast_channels.subtitle as podcast_subtitle,
-        podcast_channels.summary as podcast_summary,
-        podcast_channels.keywords as podcast_keywords,
-        podcast_channels.image_url as podcast_image_url,
-        podcast_channels.xml as podcast_xml,
-        podcast_channels.edit_date as podcast_edit_date ".
-
-        "FROM shows LEFT JOIN hosts on hosts.id = shows.host_id
-                    LEFT JOIN podcast_channels on podcast_channels.id = shows.podcast_channel_id";
-    $query .=' WHERE shows.id = '.$id.'';
-
-    if($result2 = mysqli_query($db, $query)){
-
-      if (mysqli_num_rows($result2) == 0) {
-
-        $error .= 'no show with this id:'.$id;
-        $blame_request = true;
-        finish();
-
-      } else {
-
-        while ($row = mysqli_fetch_assoc($result2)) {
-
-          $rawdata [] = $row;
-
-        }
-
-      }
-
-    }
-
-  } else {
-
-    while ($row = mysqli_fetch_assoc($result)) {
-
-      $rawdata [] = $row;
-
-    }
-
-  }
-
-} else {
-
-  $error .= "\n database error. the problematic query is: ".$query." \n".mysqli_error($db);
-
+	$show_id = isset($data['show_id']) ? $data['show_id'] : 0;
+	if ($show_id) {
+		$query = "SELECT
+					social_name,
+					social_url,
+					short_name
+				  from social
+				  where show_id = $show_id";
+		$social = array();
+		if ($result = mysqli_query($db, $query)) {
+			while ($row = mysqli_fetch_assoc($result)) {
+			    $social[] = array(
+			    	'type'  =>  html_entity_decode($row['social_name'],ENT_QUOTES),
+			        'url'   =>  html_entity_decode($row['social_url'],ENT_QUOTES),
+			        'name'  =>  html_entity_decode($row['short_name'],ENT_QUOTES)
+				);
+			}
+		}
+		$data['social_links'] = $social;
+	}
 }
 
-
-
-$data = $rawdata[0];
-
-
-if ($data['alerts'] == ''){
-  $data['alerts'] = 'I am the show alert text for '.$data['name'].'! Check out an upcoming episode on unique dog breeds and the hottest dogetronica music!';
-}
-
-
-
-
-$social_array = array();
-
-foreach($rawdata as $i => $show){
-  if (isset($show['social_name'])){
-    $social_array []= array(
-        'type'  =>  html_entity_decode($show['social_name'],ENT_QUOTES),
-        'url'   =>  html_entity_decode($show['social_url'],ENT_QUOTES),
-        'name'  =>  html_entity_decode($show['short_name'],ENT_QUOTES)
+if (empty($data)) {
+	//$error = ' no show with this id:'.$id;
+    //$blame_request = true;
+    $data = array(
+    	'api_message' => '[NO RECORD FOUND]',
+    	'message'     => 'no show with this id:'.$id,
     );
-  }
+    finish();
+    exit;
 }
-
-
-$data['social_links'] = $social_array;
-
-$data['edit_date'] = max($data['edit_date'], $data['podcast_edit_date']);
-
-unset($data['podcast_edit_date']);
-
-unset($data['social_name']);
-unset($data['social_url']);
-unset($data['short_name']);
-unset($data['unlink']);
-
 
 finish();

--- a/api/shows/index.php
+++ b/api/shows/index.php
@@ -8,44 +8,26 @@
 
 require_once('../api_common.php');
 
+$offset = isset($_GET['OFFSET']) && is_numeric($_GET['OFFSET']) ? $_GET['OFFSET'] * 1 : 0;
+$limit  = isset($_GET['LIMIT'])  && is_numeric($_GET['LIMIT'])  ? $_GET['LIMIT']  * 1 : 100;
 
-if(isset($_GET['OFFSET'])) $offset = $_GET['OFFSET']; else $offset = 0;
-if(isset($_GET['LIMIT'])) $limit = $_GET['LIMIT']; else $limit = 100;
+$query =   "SELECT 	shows.id as id,
+					GREATEST(shows.edit_date,COALESCE(podcast_channels.edit_date,'0000-00-00 00:00:00')) as edit_date
+			FROM shows
+			LEFT JOIN podcast_channels on podcast_channels.id = shows.podcast_channel_id
+			ORDER BY GREATEST(shows.edit_date,COALESCE(podcast_channels.edit_date,'0000-00-00 00:00:00')) DESC
+			LIMIT $limit
+			OFFSET $offset";
 
-$query = 'SELECT shows.id as id,
-                shows.edit_date as edit_date,
-                shows.active as active,
-                podcast_channels.edit_date as podcast_edit_date,
-                podcast_channels.id as podcast_id
-                FROM shows
-                JOIN podcast_channels on podcast_channels.id = shows.podcast_channel_id ';//ORDER BY edit_date DESC limit '.$limit.' OFFSET '.$offset;
-
-
-$rawdata = array();
+$data = array();
 
 if ($result = mysqli_query($db, $query) ) {
 
   while ($row = mysqli_fetch_assoc($result)) {
 
-    $rawdata [] = $row;
+    $data[] = $row;
 
   }
 }
-
-
-foreach($rawdata as $i => $row){
-  $rawdata[$i]['edit_date'] = max($row['edit_date'], $row['podcast_edit_date']);
-  unset($rawdata[$i]['podcast_edit_date']);
-  unset($rawdata[$i]['podcast_id']);
-}
-
-foreach($rawdata as $i => $row){
-  $edit[$i] = $row['edit_date'];
-}
-
-array_multisort($edit,SORT_DESC,$rawdata);
-
-
-$data = array_slice($rawdata,$offset,$limit);
 
 finish();


### PR DESCRIPTION
Hey Evan,

Here are the details of the changes:


(1) api_common.php
- Removed if ( is_array($data) && sizeof($data) == 1 ) $data = $data[0];
It flattens the array if only 1 record exists in it
This behaviour is not expected when getting multiple pages of results from GET SHOWS or GET PLAYLISTS.

(2) playlist/index.php
- cleaned up code
- added a better way to get the most recent edit date
- added a join to shows table to ensure that playlist has an associated show
- removed check for 0 playitems in playlist.  I think playlists are valid even with no playitems. Evan can you verify?
- improved error messaging.  Needed a way to determine if no playlist exists so I can do stuff on the citr side

(3) api/playlists/index.php
- cleaned up code
- cleaned up the query
- get the correct edit date even when left join results with no podcast_episode
- check for playlist status =2 since GET PLAYLIST does the same check
- added a join to shows table to ensure that playlist has an associated show

(4) api/show/index.php
- cleaned up and simplified the code
- do query for social links in a separate query from main query
- improved error messaging.  Needed a way to determine if no show exists so I can do stuff on the citr side
- removed dummy alerts that were created for each show

(5) api/shows/index.php
- cleaned up the code + query
- better logic for dealing with null podcast_channels join
- better logic for the limit/offset and sorting
